### PR TITLE
This changes the 1.0.0 instructions to be functional.

### DIFF
--- a/1-0-0.md
+++ b/1-0-0.md
@@ -15,6 +15,7 @@ To enter RCM and launch CFW on firmware 1.0.0, it is possible to use an nsp call
 - The latest version of [PegaSwitch](https://github.com/reswitched/PegaSwitch){: .a-table target="_blank"}.
 - The latest version of [reboot_to_rcm.nsp](https://github.com/pixel-stuck/reboot_to_rcm/releases/latest){: .a-table target="_blank"}
 - [nsp.js](assets/nsp.js){: .a-table target="_blank"} (Press CTRL-S or Apple Key-S to save this file.)
+- The latest version of [git](https://git-scm.com/). Make sure that when installing you select to add git to the PATH (the default option should be good).
 
 ---
 
@@ -89,7 +90,9 @@ This section is intended after you have ran `evalfile usefulscripts/installFakeN
   - macOS/Linux: Enter `sudo node start.js --webapplet` and press enter.
 4. On your Switch, open the news applet.
 5. Select the `Fake News` entry and start playing the video.
-6. Finally, type `evalfile usefulscripts/nsp.js` and press enter. Your Switch will now reboot to RCM. You can follow the [main guide](index.html){: .a-table target="_blank"} to set up Atmosphére as per usual.
+6. On your computer, type `evalfile usefulscripts/nsp.js` and press enter.
+7. Press the Home button to leave the applet and open the Album applet.
+8. Your Switch will now reboot to RCM. You can follow the [main guide](index.html){: .a-table target="_blank"} to set up Atmosphére as per usual.
   - When setting up your SD card files, don't replace `hbmenu.nro`.
   - When setting up your SD card files, don't remove `reboot_to_rcm.nsp`.
 


### PR DESCRIPTION
- Added git since npm complains if you don't have it installed
- Modified reboot_to_rcm steps since it's not directly launched from Fake News.

Closes #8 when merged.